### PR TITLE
新增模块

### DIFF
--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -1,0 +1,22 @@
+from core.component import on_command
+from core.elements import MessageSession
+from core.elements import Url
+from core.utils import get_url
+
+from .mod_dl import curseforge as d
+
+mod_dl = on_command(
+    bind_prefix='mod_dl',
+    desc='下载CurseForge上的Mod。',
+    developers=['HornCopper'])
+
+@news.handle('<mod_name> {通过模组名获取模组下载链接，CloudFlare CDN支持。}')
+async def main(msg: MessageSession):
+    info = await d(msg.parsed_msg['<mod_name>'])
+    if info['msg'] != '200 OK':
+        await msg.sendMessage(info['msg'])
+    link = info["download_link"]
+    name = info["filename"]
+    status = info["status"]
+    message = f'下载链接：{link}\n文件名：{name}\n版本状态：{status}'
+    await msg.sendMessage(message)

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -7,11 +7,12 @@ from .mod_dl import curseforge as d
 mod_dl = on_command(
     bind_prefix='mod_dl',
     desc='下载CurseForge上的Mod。',
-    developers=['HornCopper'])
+    developers=['HornCopper'],
+    recommend_modules=['mcmod']))
 
-@news.handle('<mod_name> {通过模组名获取模组下载链接，CloudFlare CDN支持。}')
+@news.handle('<mod_name> <mcversion> {通过模组名获取模组下载链接，CloudFlare CDN支持。')
 async def main(msg: MessageSession):
-    info = await d(msg.parsed_msg['<mod_name>'])
+    info = await d(msg.parsed_msg['<mod_name>'],msg.parsed_msg['<mcversion>'])
     if info['msg'] != '200 OK':
         await msg.sendMessage(info['msg'])
     link = info["download_link"]

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -17,5 +17,5 @@ async def main(msg: MessageSession):
     link = info["download_link"]
     name = info["filename"]
     status = info["status"]
-    message = f'下载链接：{link}\n文件名：{name}\n版本状态：{status}'
+    message = f'下载链接：{str(Url(link))}\n文件名：{name}\n版本状态：{status}'
     await msg.sendMessage(message)

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -7,7 +7,8 @@ mod_dl = on_command(
     bind_prefix='mod_dl',
     desc='下载CurseForge上的Mod。',
     developers=['HornCopper'],
-    recommend_modules=['mcmod'])
+    recommend_modules=['mcmod'],
+    alias='moddl')
 
 
 @mod_dl.handle('<mod_name> <mcversion> {通过模组名获取模组下载链接，CloudFlare CDN支持。}')

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -8,7 +8,7 @@ mod_dl = on_command(
     bind_prefix='mod_dl',
     desc='下载CurseForge上的Mod。',
     developers=['HornCopper'],
-    recommend_modules=['mcmod']))
+    recommend_modules=['mcmod'])
 
 @news.handle('<mod_name> <mcversion> {通过模组名获取模组下载链接，CloudFlare CDN支持。')
 async def main(msg: MessageSession):

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -1,6 +1,5 @@
 from core.component import on_command
 from core.elements import MessageSession
-from core.elements import Url
 
 from .mod_dl import curseforge as d
 
@@ -10,13 +9,14 @@ mod_dl = on_command(
     developers=['HornCopper'],
     recommend_modules=['mcmod'])
 
-@news.handle('<mod_name> <mcversion> {通过模组名获取模组下载链接，CloudFlare CDN支持。')
+
+@mod_dl.handle('<mod_name> <mcversion> {通过模组名获取模组下载链接，CloudFlare CDN支持。}')
 async def main(msg: MessageSession):
-    info = await d(msg.parsed_msg['<mod_name>'],msg.parsed_msg['<mcversion>'])
-    if info['msg'] != '200 OK':
-        await msg.sendMessage(info['msg'])
+    info = await d(msg.parsed_msg['<mod_name>'], msg.parsed_msg['<mcversion>'])
+    if not info['success']:
+        return await msg.sendMessage(info['msg'])
     link = info["download_link"]
     name = info["filename"]
     status = info["status"]
-    message = f'下载链接：{str(Url(link))}\n文件名：{name}\n版本状态：{status}'
+    message = f'下载链接：{link}\n文件名：{name}\n版本状态：{status}'
     await msg.sendMessage(message)

--- a/modules/mod_dl/__init__.py
+++ b/modules/mod_dl/__init__.py
@@ -1,7 +1,6 @@
 from core.component import on_command
 from core.elements import MessageSession
 from core.elements import Url
-from core.utils import get_url
 
 from .mod_dl import curseforge as d
 

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -18,10 +18,11 @@ async def curseforge(mod_name: str,ver: str):
         return {'msg':'请不要输入中文，CurseForge暂不支持中文搜索。'}
     full_url = search_piece_1 + mod_name + search_piece_2
     html = await get_url(full_url)
-    if html == '404 page not found':
-        return {'msg':'未找到搜索结果。'}
     bs = BeautifulSoup(html,'html.parser')
-    information = bs.body.div.div.a
+    try:
+        information = bs.body.div.div.a
+    except:
+        return {'msg':'未搜索到该Mod。'}
     more_specific_html = str(information)
     id = more_specific_html[int(more_specific_html.find('id=')+3):int(more_specific_html.find('\" style='))]
     final_url = search_step_2 + id + '&ver=' + ver
@@ -39,6 +40,4 @@ async def curseforge(mod_name: str,ver: str):
     if bool(information_2.find("Release")) == True:
         status = "Beta"
     dict = {"filename":file_name,"download_link":download_link,"status":status,'msg':'200 OK'}
-    print(dict)
     return dict
-    

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -1,0 +1,40 @@
+'''
+调用了其他API，但是已于CurseForge仓库对接。
+'''
+from bs4 import BeautifulSoup
+
+search_piece_1 = 'https://files.xmdhs.top/curseforge/s?q='
+search_piece_2 = '&type=1'
+search_step_2 = 'https://files.xmdhs.top/curseforge/history?id='
+
+def Chinese(string: str):
+    for word in string:
+        if u'\u4e00' <= word <= u'\u9fff':
+            return True
+    return False
+async def curseforge(mod_name: str,ver: str):
+    if Chinese(mod_name):
+        return '请不要输入中文，CurseForge暂不支持中文搜索。'
+    full_url = search_piece_1 + mod_name + search_piece_2
+    html = await get_url(full_url)
+    if html == '404 page not found':
+        return '未找到搜索结果。'
+    bs = BeautifulSoup(html,'html.parser')
+    information = bs.body.div.div.a
+    more_specific_html = str(information)
+    id = more_specific_html[int(more_specific_html.find('id=')+3):int(more_specific_html.find('\" style='))]
+    final_url = search_step_2 + id + '&ver=' + ver
+    html_2 = await get_url(final_url)
+    bs_2 = BeautifulSoup(html_2,'html.parser')
+    results = bs_2.body.div.div.table.tbody.find_all('tr')
+    information_2 = str(results[1])
+    download_link = information_2[int(information_2.find("\"")+1):int(information_2.find("\" target="))]
+    file_name = information_2[int(information_2.find("_blank\"")+8):int(information_2.find("</a>"))]
+    if bool(information_2.find("Beta")) == True:
+        status = "Release"
+    if bool(information_2.find("Release")) == True:
+        status = "Beta"
+    dict = {"filename":file_name,"download_link":download_link,"status":status}
+    print(dict)
+    return dict
+    

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -27,7 +27,10 @@ async def curseforge(mod_name: str,ver: str):
     final_url = search_step_2 + id + '&ver=' + ver
     html_2 = await get_url(final_url)
     bs_2 = BeautifulSoup(html_2,'html.parser')
-    results = bs_2.body.div.div.table.tbody.find_all('tr')
+    try:
+        results = bs_2.body.div.div.table.tbody.find_all('tr')
+    except:
+        return {'msg':'请不要尝试搜索不存在的Minecraft版本的Mod。'}
     information_2 = str(results[1])
     download_link = information_2[int(information_2.find("\"")+1):int(information_2.find("\" target="))]
     file_name = information_2[int(information_2.find("_blank\"")+8):int(information_2.find("</a>"))]

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -8,36 +8,39 @@ search_piece_1 = 'https://files.xmdhs.top/curseforge/s?q='
 search_piece_2 = '&type=1'
 search_step_2 = 'https://files.xmdhs.top/curseforge/history?id='
 
+
 def Chinese(string: str):
     for word in string:
         if u'\u4e00' <= word <= u'\u9fff':
             return True
     return False
-async def curseforge(mod_name: str,ver: str):
+
+
+async def curseforge(mod_name: str, ver: str):
     if Chinese(mod_name):
-        return {'msg':'请不要输入中文，CurseForge暂不支持中文搜索。'}
+        return {'msg': 'CurseForge暂不支持中文搜索。'}
     full_url = search_piece_1 + mod_name + search_piece_2
     html = await get_url(full_url)
-    bs = BeautifulSoup(html,'html.parser')
+    bs = BeautifulSoup(html, 'html.parser')
     try:
         information = bs.body.div.div.a
-    except:
-        return {'msg':'未搜索到该Mod。'}
+    except Exception:
+        return {'msg': '未搜索到该Mod。', 'success': False}
     more_specific_html = str(information)
-    id = more_specific_html[int(more_specific_html.find('id=')+3):int(more_specific_html.find('\" style='))]
+    id = more_specific_html[int(more_specific_html.find('id=') + 3):int(more_specific_html.find('\" style='))]
     final_url = search_step_2 + id + '&ver=' + ver
     html_2 = await get_url(final_url)
-    bs_2 = BeautifulSoup(html_2,'html.parser')
+    bs_2 = BeautifulSoup(html_2, 'html.parser')
     try:
         results = bs_2.body.div.div.table.tbody.find_all('tr')
-    except:
-        return {'msg':'请不要尝试搜索不存在的Minecraft版本的Mod。'}
+    except Exception:
+        return {'msg': f'此Mod没有{ver}的版本。', 'success': False}
     information_2 = str(results[1])
-    download_link = information_2[int(information_2.find("\"")+1):int(information_2.find("\" target="))]
-    file_name = information_2[int(information_2.find("_blank\"")+8):int(information_2.find("</a>"))]
-    if bool(information_2.find("Beta")) == True:
+    download_link = information_2[int(information_2.find("\"") + 1):int(information_2.find("\" target="))]
+    file_name = information_2[int(information_2.find("_blank\"") + 8):int(information_2.find("</a>"))]
+    status = '???'
+    if bool(information_2.find("Beta")):
         status = "Release"
-    if bool(information_2.find("Release")) == True:
+    if bool(information_2.find("Release")):
         status = "Beta"
-    dict = {"filename":file_name,"download_link":download_link,"status":status,'msg':'200 OK'}
-    return dict
+    return {"filename": file_name, "download_link": download_link, "status": status, "success": True}

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -18,7 +18,7 @@ def Chinese(string: str):
 
 async def curseforge(mod_name: str, ver: str):
     if Chinese(mod_name):
-        return {'msg': 'CurseForge暂不支持中文搜索。'}
+        return {'msg': 'CurseForge暂不支持中文搜索。', 'success': False}
     full_url = search_piece_1 + mod_name + search_piece_2
     html = await get_url(full_url)
     bs = BeautifulSoup(html, 'html.parser')

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -14,11 +14,11 @@ def Chinese(string: str):
     return False
 async def curseforge(mod_name: str,ver: str):
     if Chinese(mod_name):
-        return '请不要输入中文，CurseForge暂不支持中文搜索。'
+        return {'msg':'请不要输入中文，CurseForge暂不支持中文搜索。'}
     full_url = search_piece_1 + mod_name + search_piece_2
     html = await get_url(full_url)
     if html == '404 page not found':
-        return '未找到搜索结果。'
+        return {'msg':'未找到搜索结果。'}
     bs = BeautifulSoup(html,'html.parser')
     information = bs.body.div.div.a
     more_specific_html = str(information)
@@ -34,7 +34,7 @@ async def curseforge(mod_name: str,ver: str):
         status = "Release"
     if bool(information_2.find("Release")) == True:
         status = "Beta"
-    dict = {"filename":file_name,"download_link":download_link,"status":status}
+    dict = {"filename":file_name,"download_link":download_link,"status":status,'msg':'200 OK'}
     print(dict)
     return dict
     

--- a/modules/mod_dl/mod_dl.py
+++ b/modules/mod_dl/mod_dl.py
@@ -1,6 +1,7 @@
 '''
 调用了其他API，但是已于CurseForge仓库对接。
 '''
+from core.utils import get_url
 from bs4 import BeautifulSoup
 
 search_piece_1 = 'https://files.xmdhs.top/curseforge/s?q='


### PR DESCRIPTION
搓轮子 搓轮子 获取CurseForge模组的下载链接，
绕开了DDoS限制，使用了别人的搜索工具，
但那边仓库已经对接，所以理论上功能相同。

尽可能不要将其和mcmod模块进行整合。